### PR TITLE
Update header whitelist to allow threading

### DIFF
--- a/ezlist.py
+++ b/ezlist.py
@@ -253,7 +253,8 @@ class Manager:
     def _clean_mail(self, mail):
         """Delete unknown header fields but do not destroy the message"""
         whitelist = ('From', 'To', 'Subject', 'Date', 'Reply-To',
-                     'Content-Type', 'Content-Transfer-Encoding')
+                     'Content-Type', 'Content-Transfer-Encoding',
+                     'In-Reply-To', 'References', 'Message-ID')
         for header in mail.keys():
             if header not in whitelist:
                 del mail[header]


### PR DESCRIPTION
ezlist removes threading context. I suggest you keep In-Reply-To, References and Message-ID.

See [RFC2822](http://www.faqs.org/rfcs/rfc2822.html) or https://www.jwz.org/doc/threading.html for background
